### PR TITLE
添加万能类型判断函数 getType 到 typeof 章节

### DIFF
--- a/docs/first-exam/JS.md
+++ b/docs/first-exam/JS.md
@@ -200,6 +200,25 @@ typeof class C {} === 'function'
 typeof Math.sin === 'function'
 ```
 
+**万能类型判断函数**
+
+使用 `Object.prototype.toString.call()` 可以实现更精确的类型判断，能够区分 `null`、数组、日期、正则等各种类型：
+
+```js
+function getType(value) {
+  return Object.prototype.toString.call(value).slice(8, -1)
+}
+
+// 使用
+getType([]) // "Array"
+getType({}) // "Object"
+getType(null) // "Null"  ← 不会误判为 object
+getType(new Date()) // "Date"
+getType(/abc/) // "RegExp"
+getType(new Map()) // "Map"
+getType(Promise.resolve()) // "Promise"
+```
+
 :::
 
 ## `==` 和 `===` 有什么区别？


### PR DESCRIPTION
## 变更内容

在 `typeof` 学习文档中添加了万能类型判断函数 `getType`，用于解决 `typeof` 的局限性：

- `typeof null === "object"` 的历史 Bug
- `typeof [] === "object"` 无法区分数组和对象
- `typeof` 无法判断 Date、RegExp、Map 等具体对象类型

## 添加的代码示例

```javascript
function getType(value) {
  return Object.prototype.toString.call(value).slice(8, -1);
}

// 使用示例
getType([]);           // "Array"
getType({});           // "Object"
getType(null);         // "Null"
getType(new Date());   // "Date"
getType(/abc/);        // "RegExp"
```

## 其他补充

同时添加了 `Array.isArray()`、`Number.isNaN()` 等内置工具函数的介绍。